### PR TITLE
Remove auto-generated file `.catkin_workspace`

### DIFF
--- a/ros/.catkin_workspace
+++ b/ros/.catkin_workspace
@@ -1,1 +1,0 @@
-# This file currently only serves to mark the location of a catkin workspace for tool integration

--- a/ros/.gitignore
+++ b/ros/.gitignore
@@ -4,7 +4,7 @@ logs
 .vscode
 .catkin_tools
 # from Qt project
-*.creator.*
+*.creator*
 *.files
 *.includes
 


### PR DESCRIPTION
This PR does below actions:
- Removes `ros/.catkin_workspace` which is auto-generated. We use `python catkin tools` now.
- Adds Qt Creator build file `ros/*.creator*` in `ros/.gitignore`.